### PR TITLE
Fix tree builder SF4.2 dep.

### DIFF
--- a/src/Krtv/Bundle/SingleSignOnServiceProviderBundle/DependencyInjection/Configuration.php
+++ b/src/Krtv/Bundle/SingleSignOnServiceProviderBundle/DependencyInjection/Configuration.php
@@ -18,9 +18,16 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
+        if (\method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('krtv_single_sign_on_service_provider');
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('krtv_single_sign_on_service_provider');
+        }
 
-        $builder->root('krtv_single_sign_on_service_provider')
+        $rootNode
             ->children()
                 ->scalarNode('host')
                     ->isRequired()


### PR DESCRIPTION
Fix dep. "A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0."